### PR TITLE
[解答] add : 正解数、残り問題数表示を追加

### DIFF
--- a/src/components/QuestionMode.tsx
+++ b/src/components/QuestionMode.tsx
@@ -449,8 +449,8 @@ export const QuestionMode = ({
       {/* 解答フェーズの表示 */}
       {phase === 'answering' && (
         <Instruction>
-          <h3>このレベルの出題数は{sequence.length}個です</h3>
           <h3>{questionVoice === 'animal1' ? '光った順番に鳴き声を押してください' : '光った順番に数字を押してください'}</h3>
+          <h3>正解数: {correctCount} / 残り: {sequence.length - correctCount}</h3>
         </Instruction>
       )}
 


### PR DESCRIPTION
issuse https://github.com/iwa-ma/memory-game/issues/72 を基に実施