### PR TITLE
[出題] add :sp版で出題中にスクロールでボタンが隠れるのを防ぐ

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -68,3 +68,8 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+body.no-scroll {
+  overflow: hidden !important;
+  height: 100vh;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,6 +9,7 @@ import { useGameLogic } from '@/hooks/useGameLogic';
 import { FINAL_LEVEL } from '@/constants/gameConstants';
 import { LoadingContainer, LoadingText, LoadingSpinner } from '@/styles/LoadingStyles';
 import { SoundNotice } from '@/styles/NoticeStyles';
+import { useEffect } from 'react';
 
 /** ルート */
 export const Route = createFileRoute('/')({
@@ -41,6 +42,17 @@ function App() {
     setShowAllHistory,
     setIsSettingsOpen,
   } = useGameLogic();
+
+  // 出題・解答モード時にbodyへno-scrollクラスを付与(出題が隠れるのを防ぐため)
+  useEffect(() => {
+    if (gameMode !== 'waiting') {
+      window.scrollTo(0, 0); // 一番上にスクロール
+      document.body.classList.add('no-scroll');
+    } else {
+      document.body.classList.remove('no-scroll');
+    }
+    return () => document.body.classList.remove('no-scroll');
+  }, [gameMode]);
 
   /** 音声ファイル読み込み中の表示 */
   if (isLoading) {


### PR DESCRIPTION
出題・解答モードに移行時、一番上にスクロール後、スクロール操作不可にする

issuse https://github.com/iwa-ma/memory-game/issues/98 を元に実施